### PR TITLE
Replace Bower with Component Installer for Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Used by package managers
-/bower_components/*
-/node_modules/*
+/components/*
 /vendor/*
 
 # Used for temporary storage

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ libraries/plugins and some 'best practices'.
 
 ## Pre-installed packages
 
-### Composer
+### PHP packages
 
 * [cakephp/cakephp][cakephp/repo] to power the application.
 * [cakephp/migrations][migrations/repo] - the official CakePHP migrations shell.
@@ -30,7 +30,7 @@ libraries/plugins and some 'best practices'.
 minification, etc.
 * [mobiledetect/mobiledetectlib][mobiledetect/repo].
 
-##### Developer mode
+#### Development dependencies
 
 * [cakephp/bake][bake/repo] - the official CakePHP bake tool.
 * [cakephp/cakephp-codesniffer][codesniffer/repo] - the official CakePHP code
@@ -44,21 +44,18 @@ standard sniffs.
 * [gourmet/whoops][whoops/repo] to beautify errors and exceptions (only in debug
 mode).
 
-### Bower
+### CSS/JS assets
+
+Assets are installed using [robloach/component-installer][component/repo]:
 
 * [twbs/bootstrap][bootstrap]
 * [jquery/jquery][jquery]
-
-### Node
-
-* [Bower][bower] - Front-end package manager
 
 ## Get started
 
 It is assumed that you have the following installed globally:
 
 * [Composer][composer] - PHP package manager
-* [NPM][npm] - NodeJS package manager
 
 If (or once) you have them all installed, run:
 
@@ -132,7 +129,6 @@ Copyright (c) 2015, Jad Bitar and licensed under [The MIT License][mit].
 [bake/repo]://github.com/cakephp/bake
 [bootstrap]:http://getbootstrap.com
 [boris/repo]://github.com/d11wtq/boris
-[bower]:http://bower.io
 [cakephp]:http://cakephp.org
 [cakephp/2033]://github.com/cakephp/cakephp/issues/2033
 [cakephp/repo]://github.com/cakephp/cakephp
@@ -141,6 +137,7 @@ Copyright (c) 2015, Jad Bitar and licensed under [The MIT License][mit].
 [codeception/repo]://github.com/cakephp/codeception
 [codesniffer/repo]://github.com/cakephp/cakephp-codesniffer
 [composer]://getcomposer.org/doc/00-intro.md#globally
+[component/repo]://github.com/robloach/component-installer
 [debugbar/repo]://github.com/maximebf/debugbar
 [debug_kit/repo]://github.com/cakephp/debug_kit
 [dotenv/repo]://github.com/josegonzalez/php-dotenv
@@ -155,7 +152,6 @@ Copyright (c) 2015, Jad Bitar and licensed under [The MIT License][mit].
 [mit]:http://www.opensource.org/licenses/mit-license.php
 [mobiledetect/repo]://github.com/mobiledetectlib/mobiledetectlib
 [monolog/repo]://github.com/seldaek/monolog
-[npm]:http://npmjs.com
 [phinx/repo]://github.com/robmorgan/phinx
 [phpunit/repo]://github.com/sebastianbergmann/phpunit
 [puppet]:https://puppetlabs.com

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-    "name": "platform",
-    "dependencies": {
-        "bootstrap": "~3.1.1",
-        "jquery": "~2.1.0"
-  }
-}

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,10 @@
         "josegonzalez/dotenv": "~0.6",
         "markstory/asset_compress": "~3.0",
         "mobiledetect/mobiledetectlib": "~2.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "robloach/component-installer": "*",
+        "components/bootstrap": "~3.1.1",
+        "components/jquery": "~2.1.0"
     },
     "require-dev": {
         "cakephp/bake": "~1.0",
@@ -65,9 +68,7 @@
     "scripts": {
         "post-install-cmd": [
             "App\\Console\\Installer::postInstall",
-            "vendor/bin/codecept build",
-            "npm install",
-            "bower install"
+            "vendor/bin/codecept build"
         ],
         "post-autoload-dump": [
             "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"

--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -3,15 +3,15 @@ cacheConfig = true
 
 [css]
 baseUrl = /assets/
-paths[] = ROOT/bower_components/bootstrap/dist/css/*
+paths[] = ROOT/components/bootstrap/css/*
 paths[] = WEBROOT/css/*
 cachePath = WEBROOT/assets/
 
 [js]
 baseUrl = /assets/
 timestamp = true
-paths[] = ROOT/bower_components/bootstrap/dist/js/*
-paths[] = ROOT/bower_components/jquery/dist/*
+paths[] = ROOT/components/bootstrap/js/*
+paths[] = ROOT/components/jquery/*
 paths[] = WEBROOT/js/*
 cachePath = WEBROOT/assets/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,0 @@
-{
-    "name": "platform",
-    "dependencies": {
-        "bower": "^1.3.12"
-    }
-}


### PR DESCRIPTION
Found a more Composer-like installer for JS/CSS assets that also seems faster - by making less API calls (e.g. bower.json/bower.io) and making better use of the Composer cache.

Fixes #2 
